### PR TITLE
Changed instance $id getter to being aware of non standard object id's

### DIFF
--- a/src/mongolabResourceHttp.js
+++ b/src/mongolabResourceHttp.js
@@ -60,6 +60,8 @@ angular.module('mongolabResourceHttp', []).factory('$mongolabResourceHttp', ['MO
     Resource.prototype.$id = function () {
       if (this._id && this._id.$oid) {
         return this._id.$oid;
+      } else if (this._id) {
+        return this._id;
       }
     };
 


### PR DESCRIPTION
Right now we're relying on documents having a standard MongoDB object id, but it could also be any other value except an array.

See: http://www.mongodb.org/display/DOCS/Object+IDs
