### PR TITLE
Changed instance $id getter to being aware of non standard object id's

### DIFF
--- a/src/mongolabResourceHttp.js
+++ b/src/mongolabResourceHttp.js
@@ -60,6 +60,8 @@ angular.module('mongolabResourceHttp', []).factory('$mongolabResourceHttp', ['MO
     Resource.prototype.$id = function () {
       if (this._id && this._id.$oid) {
         return this._id.$oid;
+      } else if (this._id) {
+        return this._id;
       }
     };
 

--- a/test/mongolabResourceHttpSpec.js
+++ b/test/mongolabResourceHttpSpec.js
@@ -80,6 +80,11 @@ describe('mongolabResourceHttp', function () {
       expect(project.$id()).toEqual('testid');
     }));
 
+    it('should return non standard $id if defined', inject(function (Project) {
+      var project = new Project({_id:123456});
+      expect(project.$id()).toEqual(123456);
+    }));
+
     it('should support saving objects', inject(function (Project) {
       $httpBackend.expect('POST', createUrl('')).respond(testProject);
       new Project({key:'value'}).$save(successCallBack).then(function(data){


### PR DESCRIPTION
MongoDB object ids can be any type except arrays. The getter should not only return a standard MongoDB object id if present.
The mongolab API should do the verification upon saving the document.

See: http://www.mongodb.org/display/DOCS/Object+IDs
